### PR TITLE
chore: update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,13 +9,13 @@
     "test": "jest --forceExit --detectOpenHandles --coverage --verbose"
   },
   "devDependencies": {
-    "@dcl/eslint-config": "^2.3.1",
-    "@types/node": "^20.14.2",
+    "@dcl/eslint-config": "^2.4.3",
+    "@types/node": "^25.0.3",
     "@well-known-components/test-helpers": "^1.5.8",
     "eslint": "^8",
     "jest": "^30.2.0",
-    "nodemon": "^3.1.10",
-    "ts-jest": "^29.4.5",
+    "nodemon": "^3.1.11",
+    "ts-jest": "^29.4.6",
     "ts-node": "^10.9.2",
     "typescript": "^5.7.3"
   },
@@ -27,13 +27,13 @@
     "tabWidth": 2
   },
   "dependencies": {
-    "@dcl/traced-fetch-component": "^1.0.0",
+    "@dcl/traced-fetch-component": "^1.0.2",
     "@well-known-components/env-config-provider": "^1.2.0",
     "@well-known-components/fetch-component": "^3.0.0",
     "@well-known-components/http-requests-logger-component": "^2.1.0",
     "@well-known-components/http-server": "^2.1.0",
     "@well-known-components/http-tracer-component": "^1.1.0",
-    "@well-known-components/interfaces": "^1.5.1",
+    "@well-known-components/interfaces": "^1.5.2",
     "@well-known-components/logger": "^3.1.3",
     "@well-known-components/metrics": "^2.1.0",
     "@well-known-components/tracer-component": "^1.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -284,7 +284,7 @@
   dependencies:
     "@well-known-components/interfaces" "^1.5.2"
 
-"@dcl/eslint-config@^2.3.1":
+"@dcl/eslint-config@^2.4.3":
   version "2.4.3"
   resolved "https://registry.yarnpkg.com/@dcl/eslint-config/-/eslint-config-2.4.3.tgz#505f4817c6a5750e762163c42b68b113c5ea93be"
   integrity sha512-SFgQv5Fnvv1fFgXyF9VXxw4cAbJSntiID/h0qwWYDLtlxOp45KnzYDol4IqDFgnuXZOwJgU62GTmYt4/XcOqFA==
@@ -301,7 +301,7 @@
     eslint-plugin-prettier "^5.1.3"
     prettier "^3.3.2"
 
-"@dcl/traced-fetch-component@^1.0.0":
+"@dcl/traced-fetch-component@^1.0.2":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@dcl/traced-fetch-component/-/traced-fetch-component-1.0.2.tgz#5be68ced806185632cbebf1e3303c8e96c0e35b8"
   integrity sha512-ADo9itOEK0iisGHjb42vFEe9DWdJIj9jBna3zXeSnWkH+1p1Dw7F7lAkanBI0vZK3FlnrpVt5FtUR0KcmZNCLg==
@@ -1078,14 +1078,14 @@
     "@types/node" "*"
     form-data "^4.0.4"
 
-"@types/node@*":
+"@types/node@*", "@types/node@^25.0.3":
   version "25.0.3"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-25.0.3.tgz#79b9ac8318f373fbfaaf6e2784893efa9701f269"
   integrity sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA==
   dependencies:
     undici-types "~7.16.0"
 
-"@types/node@^20.14.2", "@types/node@^20.3.1":
+"@types/node@^20.3.1":
   version "20.19.27"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-20.19.27.tgz#d51333f77953a5e4e71d3b5aefa83ec5297fbb80"
   integrity sha512-N2clP5pJhB2YnZJ3PIHFk5RkygRX5WO/5f0WC08tp0wd+sv0rsJk3MqWn3CbNmT2J505a5336jaQj4ph1AdMug==
@@ -1366,7 +1366,7 @@
     "@well-known-components/interfaces" "^1.2.0"
     tslib "^2.5.0"
 
-"@well-known-components/interfaces@^1.2.0", "@well-known-components/interfaces@^1.4.1", "@well-known-components/interfaces@^1.5.1", "@well-known-components/interfaces@^1.5.2":
+"@well-known-components/interfaces@^1.2.0", "@well-known-components/interfaces@^1.4.1", "@well-known-components/interfaces@^1.5.2":
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/@well-known-components/interfaces/-/interfaces-1.5.2.tgz#ef7001a19d410459e65b216dd948d15be19e4efa"
   integrity sha512-TzKQblOci2Azczk1DZ4JL5aJW7hwq7kHrFMO4lCRMmW51bA71BtiZlq0WP72Dln067xTSoHQAU4WHCFJlGYvEQ==
@@ -3729,7 +3729,7 @@ node-releases@^2.0.27:
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.27.tgz#eedca519205cf20f650f61d56b070db111231e4e"
   integrity sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==
 
-nodemon@^3.1.10:
+nodemon@^3.1.11:
   version "3.1.11"
   resolved "https://registry.yarnpkg.com/nodemon/-/nodemon-3.1.11.tgz#04a54d1e794fbec9d8f6ffd8bf1ba9ea93a756ed"
   integrity sha512-is96t8F/1//UHAjNPHpbsNY46ELPpftGUoSVNXwUfMk/qdjSylYrWSu1XavVTBOn526kFiOR733ATgNBCQyH0g==
@@ -4353,7 +4353,7 @@ ts-api-utils@^1.0.1:
   resolved "https://registry.yarnpkg.com/ts-api-utils/-/ts-api-utils-1.4.3.tgz#bfc2215fe6528fecab2b0fba570a2e8a4263b064"
   integrity sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==
 
-ts-jest@^29.1.0, ts-jest@^29.4.5:
+ts-jest@^29.1.0, ts-jest@^29.4.6:
   version "29.4.6"
   resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-29.4.6.tgz#51cb7c133f227396818b71297ad7409bb77106e9"
   integrity sha512-fSpWtOO/1AjSNQguk43hb/JCo16oJDnMJf3CdEGNkqsEX3t0KX96xvyX1D7PfLCpVoKu4MfVrqUkFyblYoY4lA==


### PR DESCRIPTION
This pull request updates several dependencies in the `package.json` file to their latest patch or minor versions. These updates help ensure compatibility, security, and access to the latest features and bug fixes.

Dependency updates:

* Updated development dependencies: `@dcl/eslint-config` (2.3.1 → 2.4.3), `@types/node` (20.14.2 → 25.0.3), `nodemon` (3.1.10 → 3.1.11), and `ts-jest` (29.4.5 → 29.4.6).
* Updated production dependencies: `@dcl/traced-fetch-component` (1.0.0 → 1.0.2) and `@well-known-components/interfaces` (1.5.1 → 1.5.2).