### PR TITLE
fix: authorization middleware

### DIFF
--- a/src/controllers/routes.ts
+++ b/src/controllers/routes.ts
@@ -53,7 +53,7 @@ export async function setupRouter(context: GlobalContext): Promise<Router<Global
   // The withWorldName helper casts handlers to be compatible with the router's GlobalContext type.
 
   // World storage endpoints
-  router.get('/values/:key', withWorldName(getWorldStorageHandler))
+  router.get('/values/:key', withWorldName(authorizationMiddleware), withWorldName(getWorldStorageHandler))
   router.put(
     '/values/:key',
     schemaValidator.withSchemaValidatorMiddleware(UpsertStorageRequestSchema),
@@ -63,7 +63,11 @@ export async function setupRouter(context: GlobalContext): Promise<Router<Global
   router.delete('/values/:key', withWorldName(authorizationMiddleware), withWorldName(deleteWorldStorageHandler))
 
   // Player storage endpoints
-  router.get('/players/:player_address/values/:key', withWorldName(getPlayerStorageHandler))
+  router.get(
+    '/players/:player_address/values/:key',
+    withWorldName(authorizationMiddleware),
+    withWorldName(getPlayerStorageHandler)
+  )
   router.put(
     '/players/:player_address/values/:key',
     schemaValidator.withSchemaValidatorMiddleware(UpsertStorageRequestSchema),


### PR DESCRIPTION
### Summary

- Reorders the authorization middleware to check authorized addresses **before** fetching world permissions
- Adds authorization middleware to GET endpoints (`/values/:key` and `/players/:player_address/values/:key`)
- Refactors authorization middleware tests to better reflect the new flow and improve readability

### Rationale

The authoritative server (and other authorized addresses) will never have world permissions since they're infrastructure components, not world owners/deployers. By checking authorized addresses first, we avoid unnecessary calls to the world permission service when these addresses make requests.

**Before:**
1. Fetch world permissions (API call)
2. If no permission, check authorized addresses

**After:**
1. Check authorized addresses (local check)
2. If not matched, fetch world permissions (API call)

This improves performance for requests from authorized infrastructure while maintaining the same security guarantees for regular users.