### PR TITLE
feat: usage endpoints

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -32,16 +32,18 @@ tags:
     description: Endpoints for player-scoped storage (scoped by world and player address)
   - name: Env Storage
     description: Endpoints for encrypted environment variable storage (scoped by world)
+  - name: Usage
+    description: Storage usage and limits for each namespace
 
 security:
   - SignedFetch: []
 
 paths:
-  /usage:
+  /usage/world:
     get:
       operationId: getWorldStorageUsage
       tags:
-        - World Storage
+        - Usage
       summary: Get world storage usage
       description: |
         Returns current world storage usage and the configured maximum total size limit.
@@ -71,6 +73,118 @@ paths:
                     message: This endpoint requires a signed fetch request. See ADR-44.
         '401':
           description: Unauthorized - signer is not authorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                unauthorized:
+                  value:
+                    message: 'Unauthorized: Signer is not authorized to perform operations'
+        '500':
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /usage/players/{player_address}:
+    get:
+      operationId: getPlayerStorageUsage
+      tags:
+        - Usage
+      summary: Get player storage usage
+      description: |
+        Returns current usage and maximum total size limit for a specific player within the calling world.
+        The world identifier is resolved from the Signed Fetch metadata.
+      parameters:
+        - name: player_address
+          in: path
+          required: true
+          description: The player's wallet address
+          schema:
+            type: string
+            example: '0x1234567890abcdef1234567890abcdef12345678'
+      responses:
+        '200':
+          description: Usage information retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StorageUsageResponse'
+              examples:
+                usage:
+                  value:
+                    usedBytes: 300
+                    maxTotalSizeBytes: 1048576
+        '400':
+          description: Signed fetch is missing or invalid, or player address is invalid
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                signedFetchRequired:
+                  value:
+                    error: Invalid Auth Chain
+                    message: This endpoint requires a signed fetch request. See ADR-44.
+                invalidPlayerAddress:
+                  value:
+                    error: Bad request
+                    message: Invalid player address
+        '401':
+          description: Unauthorized - signer is not authorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                unauthorized:
+                  value:
+                    message: 'Unauthorized: Signer is not authorized to perform operations'
+        '500':
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /usage/env:
+    get:
+      operationId: getEnvStorageUsage
+      tags:
+        - Usage
+      summary: Get environment storage usage
+      description: |
+        Returns current env storage usage and the configured maximum total size limit for the calling world.
+        The world identifier is resolved from the Signed Fetch metadata.
+
+        **Authorization**: Only world owners and deployers can access this endpoint.
+      responses:
+        '200':
+          description: Usage information retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StorageUsageResponse'
+              examples:
+                usage:
+                  value:
+                    usedBytes: 420
+                    maxTotalSizeBytes: 262144
+        '400':
+          description: Signed fetch is missing or invalid
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                signedFetchRequired:
+                  value:
+                    error: Invalid Auth Chain
+                    message: This endpoint requires a signed fetch request. See ADR-44.
+        '401':
+          description: Unauthorized - signer is not owner or deployer
           content:
             application/json:
               schema:
@@ -335,67 +449,6 @@ paths:
                   value:
                     error: Invalid Auth Chain
                     message: This endpoint requires a signed fetch request. See ADR-44.
-        '500':
-          description: Unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-
-  /players/{player_address}/usage:
-    get:
-      operationId: getPlayerStorageUsage
-      tags:
-        - Player Storage
-      summary: Get player storage usage
-      description: |
-        Returns current usage and maximum total size limit for a specific player within the calling world.
-        The world identifier is resolved from the Signed Fetch metadata.
-      parameters:
-        - name: player_address
-          in: path
-          required: true
-          description: The player's wallet address
-          schema:
-            type: string
-            example: '0x1234567890abcdef1234567890abcdef12345678'
-      responses:
-        '200':
-          description: Usage information retrieved successfully
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/StorageUsageResponse'
-              examples:
-                usage:
-                  value:
-                    usedBytes: 300
-                    maxTotalSizeBytes: 1048576
-        '400':
-          description: Signed fetch is missing or invalid, or player address is invalid
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-              examples:
-                signedFetchRequired:
-                  value:
-                    error: Invalid Auth Chain
-                    message: This endpoint requires a signed fetch request. See ADR-44.
-                invalidPlayerAddress:
-                  value:
-                    error: Bad request
-                    message: Invalid player address
-        '401':
-          description: Unauthorized - signer is not authorized
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-              examples:
-                unauthorized:
-                  value:
-                    message: 'Unauthorized: Signer is not authorized to perform operations'
         '500':
           description: Unexpected error
           content:
@@ -917,57 +970,6 @@ paths:
                     message: 'Missing required header: X-Confirm-Delete-All'
         '401':
           description: Unauthorized - signer is not authorized
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-              examples:
-                unauthorized:
-                  value:
-                    message: 'Unauthorized: Signer is not authorized to perform operations'
-        '500':
-          description: Unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-
-  /env/usage:
-    get:
-      operationId: getEnvStorageUsage
-      tags:
-        - Env Storage
-      summary: Get environment storage usage
-      description: |
-        Returns current env storage usage and the configured maximum total size limit for the calling world.
-        The world identifier is resolved from the Signed Fetch metadata.
-
-        **Authorization**: Only world owners and deployers can access this endpoint.
-      responses:
-        '200':
-          description: Usage information retrieved successfully
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/StorageUsageResponse'
-              examples:
-                usage:
-                  value:
-                    usedBytes: 420
-                    maxTotalSizeBytes: 262144
-        '400':
-          description: Signed fetch is missing or invalid
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-              examples:
-                signedFetchRequired:
-                  value:
-                    error: Invalid Auth Chain
-                    message: This endpoint requires a signed fetch request. See ADR-44.
-        '401':
-          description: Unauthorized - signer is not owner or deployer
           content:
             application/json:
               schema:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -37,6 +37,55 @@ security:
   - SignedFetch: []
 
 paths:
+  /usage:
+    get:
+      operationId: getWorldStorageUsage
+      tags:
+        - World Storage
+      summary: Get world storage usage
+      description: |
+        Returns current world storage usage and the configured maximum total size limit.
+        The world identifier is resolved from the Signed Fetch metadata.
+      responses:
+        '200':
+          description: Usage information retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StorageUsageResponse'
+              examples:
+                usage:
+                  value:
+                    usedBytes: 1200
+                    maxTotalSizeBytes: 10485760
+        '400':
+          description: Signed fetch is missing or invalid
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                signedFetchRequired:
+                  value:
+                    error: Invalid Auth Chain
+                    message: This endpoint requires a signed fetch request. See ADR-44.
+        '401':
+          description: Unauthorized - signer is not authorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                unauthorized:
+                  value:
+                    message: 'Unauthorized: Signer is not authorized to perform operations'
+        '500':
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   /values:
     get:
       operationId: listWorldStorageValues
@@ -286,6 +335,67 @@ paths:
                   value:
                     error: Invalid Auth Chain
                     message: This endpoint requires a signed fetch request. See ADR-44.
+        '500':
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /players/{player_address}/usage:
+    get:
+      operationId: getPlayerStorageUsage
+      tags:
+        - Player Storage
+      summary: Get player storage usage
+      description: |
+        Returns current usage and maximum total size limit for a specific player within the calling world.
+        The world identifier is resolved from the Signed Fetch metadata.
+      parameters:
+        - name: player_address
+          in: path
+          required: true
+          description: The player's wallet address
+          schema:
+            type: string
+            example: '0x1234567890abcdef1234567890abcdef12345678'
+      responses:
+        '200':
+          description: Usage information retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StorageUsageResponse'
+              examples:
+                usage:
+                  value:
+                    usedBytes: 300
+                    maxTotalSizeBytes: 1048576
+        '400':
+          description: Signed fetch is missing or invalid, or player address is invalid
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                signedFetchRequired:
+                  value:
+                    error: Invalid Auth Chain
+                    message: This endpoint requires a signed fetch request. See ADR-44.
+                invalidPlayerAddress:
+                  value:
+                    error: Bad request
+                    message: Invalid player address
+        '401':
+          description: Unauthorized - signer is not authorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                unauthorized:
+                  value:
+                    message: 'Unauthorized: Signer is not authorized to perform operations'
         '500':
           description: Unexpected error
           content:
@@ -822,6 +932,57 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /env/usage:
+    get:
+      operationId: getEnvStorageUsage
+      tags:
+        - Env Storage
+      summary: Get environment storage usage
+      description: |
+        Returns current env storage usage and the configured maximum total size limit for the calling world.
+        The world identifier is resolved from the Signed Fetch metadata.
+
+        **Authorization**: Only world owners and deployers can access this endpoint.
+      responses:
+        '200':
+          description: Usage information retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StorageUsageResponse'
+              examples:
+                usage:
+                  value:
+                    usedBytes: 420
+                    maxTotalSizeBytes: 262144
+        '400':
+          description: Signed fetch is missing or invalid
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                signedFetchRequired:
+                  value:
+                    error: Invalid Auth Chain
+                    message: This endpoint requires a signed fetch request. See ADR-44.
+        '401':
+          description: Unauthorized - signer is not owner or deployer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                unauthorized:
+                  value:
+                    message: 'Unauthorized: Signer is not authorized to perform operations'
+        '500':
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   /env/{key}:
     get:
       operationId: getEnvStorageValue
@@ -1093,6 +1254,21 @@ components:
       required:
         - value
       description: Stored environment variable value response.
+    StorageUsageResponse:
+      type: object
+      properties:
+        usedBytes:
+          type: integer
+          description: Current storage usage in bytes for the requested scope
+          example: 1200
+        maxTotalSizeBytes:
+          type: integer
+          description: Maximum allowed total size in bytes for the requested scope
+          example: 10485760
+      required:
+        - usedBytes
+        - maxTotalSizeBytes
+      description: Current usage and configured maximum limit for a storage scope.
     UpsertEnvStorageRequest:
       type: object
       properties:

--- a/src/adapters/env-storage/types.ts
+++ b/src/adapters/env-storage/types.ts
@@ -56,13 +56,17 @@ export interface IEnvStorageComponent {
   countKeys(worldName: string, options: Pick<PaginationOptions, 'prefix'>): Promise<number>
 
   /**
-   * Returns the existing value's plaintext byte size and the total storage size for a world
-   * in a single database query. Used by the storage limits validator to efficiently
-   * compute projected total size without fetching/decrypting the full value.
+   * Returns storage size info for env variables in a world in a single query.
+   *
+   * When `key` is provided, this includes the existing value size for that key
+   * plus total env usage for the world. Used by upsert limits validation.
+   *
+   * When `key` is omitted, `existingValueSize` is 0 and only total usage matters.
+   * Used by usage endpoints.
    *
    * @param worldName - The world identifier
-   * @param key - The environment variable key being upserted
-   * @returns The existing value's byte size (0 if key does not exist) and the total storage size
+   * @param key - Optional environment variable key
+   * @returns Existing value size and total storage size
    */
-  getUpsertSizeInfo(worldName: string, key: string): Promise<{ existingValueSize: number; totalSize: number }>
+  getSizeInfo(worldName: string, key?: string): Promise<{ existingValueSize: number; totalSize: number }>
 }

--- a/src/adapters/player-storage/types.ts
+++ b/src/adapters/player-storage/types.ts
@@ -97,18 +97,22 @@ export interface IPlayerStorageComponent {
   countPlayers(worldName: string): Promise<number>
 
   /**
-   * Returns the existing value's byte size and the total storage size for a player in a world
-   * in a single database query. Used by the storage limits validator to efficiently
-   * compute projected total size without fetching/deserializing the full value.
+   * Returns storage size info for a player scope in a world in a single query.
+   *
+   * When `key` is provided, this includes the existing value size for that key
+   * plus total usage for the player's scope. Used by upsert limits validation.
+   *
+   * When `key` is omitted, `existingValueSize` is 0 and only total usage matters.
+   * Used by usage endpoints.
    *
    * @param worldName - The world identifier
    * @param playerAddress - The player's wallet address
-   * @param key - The storage key being upserted
-   * @returns The existing value's byte size (0 if key does not exist) and the total storage size
+   * @param key - Optional storage key
+   * @returns Existing value size and total storage size
    */
-  getUpsertSizeInfo(
+  getSizeInfo(
     worldName: string,
     playerAddress: string,
-    key: string
+    key?: string
   ): Promise<{ existingValueSize: number; totalSize: number }>
 }

--- a/src/adapters/world-storage/component.ts
+++ b/src/adapters/world-storage/component.ts
@@ -165,21 +165,24 @@ export const createWorldStorageComponent = ({
   }
 
   /**
-   * Returns the existing value's byte size and the total storage size for a world
-   * in a single database query. Used by the storage limits validator to efficiently
-   * compute projected total size without fetching/deserializing the full value.
+   * Returns storage size info for a world in a single database query.
+   *
+   * If `key` is provided, this returns the existing value size for that key and
+   * the current total size for the world. If `key` is omitted, `existingValueSize`
+   * is set to 0 and only the total size is meaningful.
    *
    * @param worldName - The world identifier
-   * @param key - The storage key being upserted
-   * @returns The existing value's byte size (0 if key does not exist) and the total storage size
+   * @param key - Optional storage key
+   * @returns Existing value size and total storage size
    */
-  async function getUpsertSizeInfo(
+  async function getSizeInfo(
     worldName: string,
-    key: string
+    key?: string
   ): Promise<{ existingValueSize: number; totalSize: number }> {
+    const keyFilter = key ?? null
     const query = SQL`
       SELECT
-        COALESCE((SELECT value_size FROM world_storage WHERE world_name = ${worldName} AND key = ${key}), 0) AS existing_value_size,
+        COALESCE(MAX(value_size) FILTER (WHERE key = ${keyFilter}), 0) AS existing_value_size,
         COALESCE(SUM(value_size), 0)::int AS total_size
       FROM world_storage
       WHERE world_name = ${worldName}`
@@ -198,6 +201,6 @@ export const createWorldStorageComponent = ({
     deleteAll,
     listValues,
     countKeys,
-    getUpsertSizeInfo
+    getSizeInfo
   }
 }

--- a/src/adapters/world-storage/types.ts
+++ b/src/adapters/world-storage/types.ts
@@ -64,13 +64,17 @@ export interface IWorldStorageComponent {
   countKeys(worldName: string, options: Pick<PaginationOptions, 'prefix'>): Promise<number>
 
   /**
-   * Returns the existing value's byte size and the total storage size for a world
-   * in a single database query. Used by the storage limits validator to efficiently
-   * compute projected total size without fetching/deserializing the full value.
+   * Returns storage size info for a world in a single database query.
+   *
+   * When `key` is provided, this includes the existing value size for that key
+   * plus the total storage size for the world. Used by upsert limits validation.
+   *
+   * When `key` is omitted, `existingValueSize` is always 0 and only total usage
+   * is relevant. Used by usage endpoints.
    *
    * @param worldName - The world identifier
-   * @param key - The storage key being upserted
-   * @returns The existing value's byte size (0 if key does not exist) and the total storage size
+   * @param key - Optional storage key
+   * @returns Existing value size and total storage size
    */
-  getUpsertSizeInfo(worldName: string, key: string): Promise<{ existingValueSize: number; totalSize: number }>
+  getSizeInfo(worldName: string, key?: string): Promise<{ existingValueSize: number; totalSize: number }>
 }

--- a/src/controllers/handlers/env-storage/get-env-usage.ts
+++ b/src/controllers/handlers/env-storage/get-env-usage.ts
@@ -1,0 +1,40 @@
+import { errorMessageOrDefault } from '../../../utils/errors'
+import type { WorldHandlerContextWithPath } from '../../../types'
+import type { HTTPStorageUsageResponse } from '../../../types/http'
+
+export async function getEnvUsageHandler(
+  context: Pick<WorldHandlerContextWithPath<'logs' | 'envStorage' | 'config', '/env/usage'>, 'components' | 'worldName'>
+): Promise<HTTPStorageUsageResponse> {
+  const {
+    worldName,
+    components: { logs, envStorage, config }
+  } = context
+
+  const logger = logs.getLogger('get-env-usage-handler')
+
+  logger.debug('Processing env usage request', { worldName })
+
+  try {
+    const [{ totalSize: usedBytes }, maxTotalSizeBytes] = await Promise.all([
+      envStorage.getSizeInfo(worldName),
+      config.requireNumber('ENV_STORAGE_MAX_TOTAL_SIZE_BYTES')
+    ])
+
+    logger.info('Env usage retrieved successfully', { worldName, usedBytes, maxTotalSizeBytes })
+
+    return {
+      status: 200,
+      body: {
+        usedBytes,
+        maxTotalSizeBytes
+      }
+    }
+  } catch (error) {
+    logger.error('Error getting env usage', {
+      worldName,
+      error: errorMessageOrDefault(error, 'Unknown error')
+    })
+
+    throw error
+  }
+}

--- a/src/controllers/handlers/player-storage/get-player-usage.ts
+++ b/src/controllers/handlers/player-storage/get-player-usage.ts
@@ -41,10 +41,6 @@ export async function getPlayerUsageHandler(
       }
     }
   } catch (error) {
-    if (error instanceof InvalidRequestError) {
-      throw error
-    }
-
     logger.error('Error getting player usage', {
       worldName,
       playerAddress,

--- a/src/controllers/handlers/player-storage/get-player-usage.ts
+++ b/src/controllers/handlers/player-storage/get-player-usage.ts
@@ -1,0 +1,56 @@
+import { InvalidRequestError } from '@dcl/http-commons'
+import { EthAddress } from '@dcl/schemas'
+import { errorMessageOrDefault } from '../../../utils/errors'
+import type { WorldHandlerContextWithPath } from '../../../types'
+import type { HTTPStorageUsageResponse } from '../../../types/http'
+
+export async function getPlayerUsageHandler(
+  context: Pick<
+    WorldHandlerContextWithPath<'logs' | 'playerStorage' | 'config', '/players/:player_address/usage'>,
+    'components' | 'worldName' | 'params'
+  >
+): Promise<HTTPStorageUsageResponse> {
+  const {
+    params,
+    worldName,
+    components: { logs, playerStorage, config }
+  } = context
+
+  const logger = logs.getLogger('get-player-usage-handler')
+  const playerAddress = params.player_address.toLowerCase()
+
+  logger.debug('Processing player usage request', { worldName, playerAddress })
+
+  if (!EthAddress.validate(playerAddress)) {
+    throw new InvalidRequestError('Invalid player address')
+  }
+
+  try {
+    const [{ totalSize: usedBytes }, maxTotalSizeBytes] = await Promise.all([
+      playerStorage.getSizeInfo(worldName, playerAddress),
+      config.requireNumber('PLAYER_STORAGE_MAX_TOTAL_SIZE_BYTES')
+    ])
+
+    logger.info('Player usage retrieved successfully', { worldName, playerAddress, usedBytes, maxTotalSizeBytes })
+
+    return {
+      status: 200,
+      body: {
+        usedBytes,
+        maxTotalSizeBytes
+      }
+    }
+  } catch (error) {
+    if (error instanceof InvalidRequestError) {
+      throw error
+    }
+
+    logger.error('Error getting player usage', {
+      worldName,
+      playerAddress,
+      error: errorMessageOrDefault(error, 'Unknown error')
+    })
+
+    throw error
+  }
+}

--- a/src/controllers/handlers/world-storage/get-world-usage.ts
+++ b/src/controllers/handlers/world-storage/get-world-usage.ts
@@ -1,0 +1,40 @@
+import { errorMessageOrDefault } from '../../../utils/errors'
+import type { WorldHandlerContextWithPath } from '../../../types'
+import type { HTTPStorageUsageResponse } from '../../../types/http'
+
+export async function getWorldUsageHandler(
+  context: Pick<WorldHandlerContextWithPath<'logs' | 'worldStorage' | 'config', '/usage'>, 'components' | 'worldName'>
+): Promise<HTTPStorageUsageResponse> {
+  const {
+    worldName,
+    components: { logs, worldStorage, config }
+  } = context
+
+  const logger = logs.getLogger('get-world-usage-handler')
+
+  logger.debug('Processing world usage request', { worldName })
+
+  try {
+    const [{ totalSize: usedBytes }, maxTotalSizeBytes] = await Promise.all([
+      worldStorage.getSizeInfo(worldName),
+      config.requireNumber('WORLD_STORAGE_MAX_TOTAL_SIZE_BYTES')
+    ])
+
+    logger.info('World usage retrieved successfully', { worldName, usedBytes, maxTotalSizeBytes })
+
+    return {
+      status: 200,
+      body: {
+        usedBytes,
+        maxTotalSizeBytes
+      }
+    }
+  } catch (error) {
+    logger.error('Error getting world usage', {
+      worldName,
+      error: errorMessageOrDefault(error, 'Unknown error')
+    })
+
+    throw error
+  }
+}

--- a/src/controllers/routes.ts
+++ b/src/controllers/routes.ts
@@ -6,6 +6,7 @@ import { wellKnownComponents } from '@dcl/platform-crypto-middleware'
 import { clearEnvStorageHandler } from './handlers/env-storage/clear-env-storage'
 import { deleteEnvStorageHandler } from './handlers/env-storage/delete-env-storage'
 import { getEnvStorageHandler } from './handlers/env-storage/get-env-storage'
+import { getEnvUsageHandler } from './handlers/env-storage/get-env-usage'
 import { listEnvKeysHandler } from './handlers/env-storage/list-env-keys'
 import { upsertEnvStorageHandler } from './handlers/env-storage/upsert-env-storage'
 import {
@@ -14,6 +15,7 @@ import {
 } from './handlers/player-storage/clear-player-storage'
 import { deletePlayerStorageHandler } from './handlers/player-storage/delete-player-storage'
 import { getPlayerStorageHandler } from './handlers/player-storage/get-player-storage'
+import { getPlayerUsageHandler } from './handlers/player-storage/get-player-usage'
 import { listPlayerStorageHandler } from './handlers/player-storage/list-player-storage'
 import { listPlayersHandler } from './handlers/player-storage/list-players'
 import { upsertPlayerStorageHandler } from './handlers/player-storage/upsert-player-storage'
@@ -21,6 +23,7 @@ import { UpsertEnvStorageRequestSchema, UpsertStorageRequestSchema } from './han
 import { clearWorldStorageHandler } from './handlers/world-storage/clear-world-storage'
 import { deleteWorldStorageHandler } from './handlers/world-storage/delete-world-storage'
 import { getWorldStorageHandler } from './handlers/world-storage/get-world-storage'
+import { getWorldUsageHandler } from './handlers/world-storage/get-world-usage'
 import { listWorldStorageHandler } from './handlers/world-storage/list-world-storage'
 import { upsertWorldStorageHandler } from './handlers/world-storage/upsert-world-storage'
 import {
@@ -67,6 +70,7 @@ export async function setupRouter(context: GlobalContext): Promise<Router<Global
   // The withWorldName helper casts handlers to be compatible with the router's GlobalContext type.
 
   // World storage endpoints
+  router.get('/usage', withWorldName(authorizationMiddleware), withWorldName(getWorldUsageHandler))
   router.get('/values', withWorldName(authorizationMiddleware), withWorldName(listWorldStorageHandler))
   router.get('/values/:key', withWorldName(authorizationMiddleware), withWorldName(getWorldStorageHandler))
   router.put(
@@ -84,6 +88,11 @@ export async function setupRouter(context: GlobalContext): Promise<Router<Global
 
   // Player storage endpoints
   router.get('/players', withWorldName(authorizationMiddleware), withWorldName(listPlayersHandler))
+  router.get(
+    '/players/:player_address/usage',
+    withWorldName(authorizationMiddleware),
+    withWorldName(getPlayerUsageHandler)
+  )
   router.get(
     '/players/:player_address/values',
     withWorldName(authorizationMiddleware),
@@ -118,6 +127,11 @@ export async function setupRouter(context: GlobalContext): Promise<Router<Global
 
   // Env storage endpoints
   router.get('/env', withWorldName(ownerAndDeployerOnlyAuthorizationMiddleware), withWorldName(listEnvKeysHandler))
+  router.get(
+    '/env/usage',
+    withWorldName(ownerAndDeployerOnlyAuthorizationMiddleware),
+    withWorldName(getEnvUsageHandler)
+  )
   router.get(
     '/env/:key',
     withWorldName(authorizedAddressesOnlyAuthorizationMiddleware),

--- a/src/controllers/routes.ts
+++ b/src/controllers/routes.ts
@@ -69,8 +69,20 @@ export async function setupRouter(context: GlobalContext): Promise<Router<Global
   // All handlers below run after worldNameMiddleware, so worldName is guaranteed to be present.
   // The withWorldName helper casts handlers to be compatible with the router's GlobalContext type.
 
+  // Usage endpoints
+  router.get('/usage/world', withWorldName(authorizationMiddleware), withWorldName(getWorldUsageHandler))
+  router.get(
+    '/usage/players/:player_address',
+    withWorldName(authorizationMiddleware),
+    withWorldName(getPlayerUsageHandler)
+  )
+  router.get(
+    '/usage/env',
+    withWorldName(ownerAndDeployerOnlyAuthorizationMiddleware),
+    withWorldName(getEnvUsageHandler)
+  )
+
   // World storage endpoints
-  router.get('/usage', withWorldName(authorizationMiddleware), withWorldName(getWorldUsageHandler))
   router.get('/values', withWorldName(authorizationMiddleware), withWorldName(listWorldStorageHandler))
   router.get('/values/:key', withWorldName(authorizationMiddleware), withWorldName(getWorldStorageHandler))
   router.put(
@@ -88,11 +100,6 @@ export async function setupRouter(context: GlobalContext): Promise<Router<Global
 
   // Player storage endpoints
   router.get('/players', withWorldName(authorizationMiddleware), withWorldName(listPlayersHandler))
-  router.get(
-    '/players/:player_address/usage',
-    withWorldName(authorizationMiddleware),
-    withWorldName(getPlayerUsageHandler)
-  )
   router.get(
     '/players/:player_address/values',
     withWorldName(authorizationMiddleware),
@@ -127,11 +134,6 @@ export async function setupRouter(context: GlobalContext): Promise<Router<Global
 
   // Env storage endpoints
   router.get('/env', withWorldName(ownerAndDeployerOnlyAuthorizationMiddleware), withWorldName(listEnvKeysHandler))
-  router.get(
-    '/env/usage',
-    withWorldName(ownerAndDeployerOnlyAuthorizationMiddleware),
-    withWorldName(getEnvUsageHandler)
-  )
   router.get(
     '/env/:key',
     withWorldName(authorizedAddressesOnlyAuthorizationMiddleware),

--- a/src/logic/storage-limits/component.ts
+++ b/src/logic/storage-limits/component.ts
@@ -80,7 +80,7 @@ export async function createStorageLimitsComponent(
 
   return {
     async validateWorldStorageUpsert(worldName: string, key: string, value: unknown): Promise<void> {
-      const validate = createUpsertValidator(() => worldStorage.getUpsertSizeInfo(worldName, key), worldLimits)
+      const validate = createUpsertValidator(() => worldStorage.getSizeInfo(worldName, key), worldLimits)
       await validate(JSON.stringify(value))
     },
 
@@ -91,14 +91,14 @@ export async function createStorageLimitsComponent(
       value: unknown
     ): Promise<void> {
       const validate = createUpsertValidator(
-        () => playerStorage.getUpsertSizeInfo(worldName, playerAddress, key),
+        () => playerStorage.getSizeInfo(worldName, playerAddress, key),
         playerLimits
       )
       await validate(JSON.stringify(value))
     },
 
     async validateEnvStorageUpsert(worldName: string, key: string, value: string): Promise<void> {
-      const validate = createUpsertValidator(() => envStorage.getUpsertSizeInfo(worldName, key), envLimits)
+      const validate = createUpsertValidator(() => envStorage.getSizeInfo(worldName, key), envLimits)
       await validate(value)
     }
   }

--- a/src/types/http.ts
+++ b/src/types/http.ts
@@ -44,4 +44,14 @@ export interface HTTPPaginatedResponse<T> {
   }
 }
 
+export interface StorageUsageResponse {
+  usedBytes: number
+  maxTotalSizeBytes: number
+}
+
+export interface HTTPStorageUsageResponse {
+  status: number
+  body: StorageUsageResponse
+}
+
 export type JSONValue = string | number | boolean | null | JSONValue[] | { [key: string]: JSONValue }

--- a/test/integration/env-storage/get-env-usage-controller.spec.ts
+++ b/test/integration/env-storage/get-env-usage-controller.spec.ts
@@ -29,7 +29,7 @@ test('when getting env storage usage', function ({ components, stubComponents })
     let response: Awaited<ReturnType<typeof signedFetch>>
 
     beforeEach(async () => {
-      response = await signedFetch(`${baseUrl}/env/usage`, { method: 'GET' })
+      response = await signedFetch(`${baseUrl}/usage/env`, { method: 'GET' })
     })
 
     it('should respond with a 400 and a signed fetch required message', async () => {
@@ -53,7 +53,7 @@ test('when getting env storage usage', function ({ components, stubComponents })
         metadata: TEST_REALM_METADATA
       })
 
-      response = await signedFetch(`${baseUrl}/env/usage`, {
+      response = await signedFetch(`${baseUrl}/usage/env`, {
         method: 'GET',
         identity,
         metadata: TEST_REALM_METADATA
@@ -104,7 +104,7 @@ test('when getting env storage usage', function ({ components, stubComponents })
     })
 
     it('should respond with a 200 and the current usage and max limit', async () => {
-      const response = await signedFetch(`${baseUrl}/env/usage`, {
+      const response = await signedFetch(`${baseUrl}/usage/env`, {
         method: 'GET',
         identity,
         metadata: TEST_REALM_METADATA
@@ -129,7 +129,7 @@ test('when getting env storage usage', function ({ components, stubComponents })
     })
 
     it('should respond with a 500 and the error message', async () => {
-      const response = await signedFetch(`${baseUrl}/env/usage`, {
+      const response = await signedFetch(`${baseUrl}/usage/env`, {
         method: 'GET',
         identity,
         metadata: TEST_REALM_METADATA

--- a/test/integration/env-storage/get-env-usage-controller.spec.ts
+++ b/test/integration/env-storage/get-env-usage-controller.spec.ts
@@ -1,0 +1,145 @@
+import type { AuthIdentity } from '@dcl/crypto'
+import type { signedFetchFactory } from 'decentraland-crypto-fetch'
+import { calculateValueSizeInBytes } from '../../../src/utils/calculateValueSizeInBytes'
+import { test } from '../../components'
+import { TEST_REALM_METADATA } from '../utils/auth'
+import { createTestSetup } from '../utils/setup'
+
+test('when getting env storage usage', function ({ components, stubComponents }) {
+  let signedFetch: ReturnType<typeof signedFetchFactory>
+  let baseUrl: string
+  let resetStubs: () => void
+  let identity: AuthIdentity
+  let maxTotalSizeBytes: number
+
+  beforeEach(async () => {
+    const setup = await createTestSetup(components, stubComponents)
+    signedFetch = setup.signedFetch
+    baseUrl = setup.baseUrl
+    identity = setup.identity
+    resetStubs = setup.resetStubs
+    maxTotalSizeBytes = await components.config.requireNumber('ENV_STORAGE_MAX_TOTAL_SIZE_BYTES')
+  })
+
+  afterEach(() => {
+    resetStubs()
+  })
+
+  describe('and the request does not include an identity', () => {
+    let response: Awaited<ReturnType<typeof signedFetch>>
+
+    beforeEach(async () => {
+      response = await signedFetch(`${baseUrl}/env/usage`, { method: 'GET' })
+    })
+
+    it('should respond with a 400 and a signed fetch required message', async () => {
+      const body = await response.json()
+      expect(response.status).toBe(400)
+      expect(body).toEqual({
+        error: 'Invalid Auth Chain',
+        message: 'This endpoint requires a signed fetch request. See ADR-44.'
+      })
+    })
+  })
+
+  describe('and no env values exist', () => {
+    let response: Awaited<ReturnType<typeof signedFetch>>
+
+    beforeEach(async () => {
+      await signedFetch(`${baseUrl}/env`, {
+        method: 'DELETE',
+        headers: { 'X-Confirm-Delete-All': 'true' },
+        identity,
+        metadata: TEST_REALM_METADATA
+      })
+
+      response = await signedFetch(`${baseUrl}/env/usage`, {
+        method: 'GET',
+        identity,
+        metadata: TEST_REALM_METADATA
+      })
+    })
+
+    it('should respond with a 200 and zero used bytes', async () => {
+      const body = await response.json()
+      expect(response.status).toBe(200)
+      expect(body).toEqual({
+        usedBytes: 0,
+        maxTotalSizeBytes
+      })
+    })
+  })
+
+  describe('and env values exist', () => {
+    let expectedUsedBytes: number
+
+    beforeEach(async () => {
+      const envEntries = [
+        { key: 'API_SECRET', value: 'secret-123' },
+        { key: 'DATABASE_URL', value: 'postgres://example' },
+        { key: 'SENTRY_DSN', value: 'dsn-value' }
+      ]
+      expectedUsedBytes = envEntries.reduce((total, item) => total + calculateValueSizeInBytes(item.value), 0)
+
+      await Promise.all(
+        envEntries.map(item =>
+          signedFetch(`${baseUrl}/env/${item.key}`, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ value: item.value }),
+            identity,
+            metadata: TEST_REALM_METADATA
+          })
+        )
+      )
+    })
+
+    afterEach(async () => {
+      await signedFetch(`${baseUrl}/env`, {
+        method: 'DELETE',
+        headers: { 'X-Confirm-Delete-All': 'true' },
+        identity,
+        metadata: TEST_REALM_METADATA
+      })
+    })
+
+    it('should respond with a 200 and the current usage and max limit', async () => {
+      const response = await signedFetch(`${baseUrl}/env/usage`, {
+        method: 'GET',
+        identity,
+        metadata: TEST_REALM_METADATA
+      })
+      const body = await response.json()
+
+      expect(response.status).toBe(200)
+      expect(body).toEqual({
+        usedBytes: expectedUsedBytes,
+        maxTotalSizeBytes
+      })
+    })
+  })
+
+  describe('and the storage throws an error', () => {
+    beforeEach(() => {
+      stubComponents.envStorage.getSizeInfo.rejects(new Error('boom'))
+    })
+
+    afterEach(() => {
+      stubComponents.envStorage.getSizeInfo.reset()
+    })
+
+    it('should respond with a 500 and the error message', async () => {
+      const response = await signedFetch(`${baseUrl}/env/usage`, {
+        method: 'GET',
+        identity,
+        metadata: TEST_REALM_METADATA
+      })
+      const body = await response.json()
+
+      expect(response.status).toBe(500)
+      expect(body).toEqual({
+        error: 'Internal Server Error'
+      })
+    })
+  })
+})

--- a/test/integration/player-storage/get-player-usage-controller.spec.ts
+++ b/test/integration/player-storage/get-player-usage-controller.spec.ts
@@ -32,7 +32,7 @@ test('when getting player storage usage', function ({ components, stubComponents
     let response: Awaited<ReturnType<typeof signedFetch>>
 
     beforeEach(async () => {
-      response = await signedFetch(`${baseUrl}/players/${playerAddress}/usage`, { method: 'GET' })
+      response = await signedFetch(`${baseUrl}/usage/players/${playerAddress}`, { method: 'GET' })
     })
 
     it('should respond with a 400 and a signed fetch required message', async () => {
@@ -47,7 +47,7 @@ test('when getting player storage usage', function ({ components, stubComponents
 
   describe('and the player address is invalid', () => {
     it('should respond with a 400 and an invalid player address message', async () => {
-      const response = await signedFetch(`${baseUrl}/players/${ADDRESSES.INVALID}/usage`, {
+      const response = await signedFetch(`${baseUrl}/usage/players/${ADDRESSES.INVALID}`, {
         method: 'GET',
         identity,
         metadata: TEST_REALM_METADATA
@@ -73,7 +73,7 @@ test('when getting player storage usage', function ({ components, stubComponents
         metadata: TEST_REALM_METADATA
       })
 
-      response = await signedFetch(`${baseUrl}/players/${playerAddress}/usage`, {
+      response = await signedFetch(`${baseUrl}/usage/players/${playerAddress}`, {
         method: 'GET',
         identity,
         metadata: TEST_REALM_METADATA
@@ -144,7 +144,7 @@ test('when getting player storage usage', function ({ components, stubComponents
     })
 
     it('should respond with a 200 and usage for the requested player only', async () => {
-      const response = await signedFetch(`${baseUrl}/players/${playerAddress}/usage`, {
+      const response = await signedFetch(`${baseUrl}/usage/players/${playerAddress}`, {
         method: 'GET',
         identity,
         metadata: TEST_REALM_METADATA
@@ -169,7 +169,7 @@ test('when getting player storage usage', function ({ components, stubComponents
     })
 
     it('should respond with a 500 and the error message', async () => {
-      const response = await signedFetch(`${baseUrl}/players/${playerAddress}/usage`, {
+      const response = await signedFetch(`${baseUrl}/usage/players/${playerAddress}`, {
         method: 'GET',
         identity,
         metadata: TEST_REALM_METADATA

--- a/test/integration/player-storage/get-player-usage-controller.spec.ts
+++ b/test/integration/player-storage/get-player-usage-controller.spec.ts
@@ -1,0 +1,185 @@
+import type { AuthIdentity } from '@dcl/crypto'
+import type { signedFetchFactory } from 'decentraland-crypto-fetch'
+import { calculateValueSizeInBytes } from '../../../src/utils/calculateValueSizeInBytes'
+import { test } from '../../components'
+import { ADDRESSES } from '../../fixtures'
+import { TEST_REALM_METADATA } from '../utils/auth'
+import { createTestSetup } from '../utils/setup'
+
+test('when getting player storage usage', function ({ components, stubComponents }) {
+  let signedFetch: ReturnType<typeof signedFetchFactory>
+  let baseUrl: string
+  let resetStubs: () => void
+  let identity: AuthIdentity
+  let playerAddress: string
+  let maxTotalSizeBytes: number
+
+  beforeEach(async () => {
+    playerAddress = ADDRESSES.PLAYER
+    const setup = await createTestSetup(components, stubComponents)
+    signedFetch = setup.signedFetch
+    baseUrl = setup.baseUrl
+    identity = setup.identity
+    resetStubs = setup.resetStubs
+    maxTotalSizeBytes = await components.config.requireNumber('PLAYER_STORAGE_MAX_TOTAL_SIZE_BYTES')
+  })
+
+  afterEach(() => {
+    resetStubs()
+  })
+
+  describe('and the request does not include an identity', () => {
+    let response: Awaited<ReturnType<typeof signedFetch>>
+
+    beforeEach(async () => {
+      response = await signedFetch(`${baseUrl}/players/${playerAddress}/usage`, { method: 'GET' })
+    })
+
+    it('should respond with a 400 and a signed fetch required message', async () => {
+      const body = await response.json()
+      expect(response.status).toBe(400)
+      expect(body).toEqual({
+        error: 'Invalid Auth Chain',
+        message: 'This endpoint requires a signed fetch request. See ADR-44.'
+      })
+    })
+  })
+
+  describe('and the player address is invalid', () => {
+    it('should respond with a 400 and an invalid player address message', async () => {
+      const response = await signedFetch(`${baseUrl}/players/${ADDRESSES.INVALID}/usage`, {
+        method: 'GET',
+        identity,
+        metadata: TEST_REALM_METADATA
+      })
+      const body = await response.json()
+
+      expect(response.status).toBe(400)
+      expect(body).toEqual({
+        error: 'Bad request',
+        message: 'Invalid player address'
+      })
+    })
+  })
+
+  describe('and no values exist for the player', () => {
+    let response: Awaited<ReturnType<typeof signedFetch>>
+
+    beforeEach(async () => {
+      await signedFetch(`${baseUrl}/players/${playerAddress}/values`, {
+        method: 'DELETE',
+        headers: { 'X-Confirm-Delete-All': 'true' },
+        identity,
+        metadata: TEST_REALM_METADATA
+      })
+
+      response = await signedFetch(`${baseUrl}/players/${playerAddress}/usage`, {
+        method: 'GET',
+        identity,
+        metadata: TEST_REALM_METADATA
+      })
+    })
+
+    it('should respond with a 200 and zero used bytes', async () => {
+      const body = await response.json()
+      expect(response.status).toBe(200)
+      expect(body).toEqual({
+        usedBytes: 0,
+        maxTotalSizeBytes
+      })
+    })
+  })
+
+  describe('and values exist for multiple players', () => {
+    let expectedUsedBytes: number
+    let anotherPlayerAddress: string
+
+    beforeEach(async () => {
+      anotherPlayerAddress = ADDRESSES.OWNER
+
+      const targetPlayerItems = [
+        { key: 'inventory', value: { items: ['sword', 'shield'] } },
+        { key: 'level', value: 5 }
+      ]
+      expectedUsedBytes = targetPlayerItems.reduce(
+        (total, item) => total + calculateValueSizeInBytes(JSON.stringify(item.value)),
+        0
+      )
+
+      await Promise.all([
+        ...targetPlayerItems.map(item =>
+          signedFetch(`${baseUrl}/players/${playerAddress}/values/${item.key}`, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ value: item.value }),
+            identity,
+            metadata: TEST_REALM_METADATA
+          })
+        ),
+        signedFetch(`${baseUrl}/players/${anotherPlayerAddress}/values/score`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ value: 1000 }),
+          identity,
+          metadata: TEST_REALM_METADATA
+        })
+      ])
+    })
+
+    afterEach(async () => {
+      await Promise.all([
+        signedFetch(`${baseUrl}/players/${playerAddress}/values`, {
+          method: 'DELETE',
+          headers: { 'X-Confirm-Delete-All': 'true' },
+          identity,
+          metadata: TEST_REALM_METADATA
+        }),
+        signedFetch(`${baseUrl}/players/${anotherPlayerAddress}/values`, {
+          method: 'DELETE',
+          headers: { 'X-Confirm-Delete-All': 'true' },
+          identity,
+          metadata: TEST_REALM_METADATA
+        })
+      ])
+    })
+
+    it('should respond with a 200 and usage for the requested player only', async () => {
+      const response = await signedFetch(`${baseUrl}/players/${playerAddress}/usage`, {
+        method: 'GET',
+        identity,
+        metadata: TEST_REALM_METADATA
+      })
+      const body = await response.json()
+
+      expect(response.status).toBe(200)
+      expect(body).toEqual({
+        usedBytes: expectedUsedBytes,
+        maxTotalSizeBytes
+      })
+    })
+  })
+
+  describe('and the storage throws an error', () => {
+    beforeEach(() => {
+      stubComponents.playerStorage.getSizeInfo.rejects(new Error('boom'))
+    })
+
+    afterEach(() => {
+      stubComponents.playerStorage.getSizeInfo.reset()
+    })
+
+    it('should respond with a 500 and the error message', async () => {
+      const response = await signedFetch(`${baseUrl}/players/${playerAddress}/usage`, {
+        method: 'GET',
+        identity,
+        metadata: TEST_REALM_METADATA
+      })
+      const body = await response.json()
+
+      expect(response.status).toBe(500)
+      expect(body).toEqual({
+        error: 'Internal Server Error'
+      })
+    })
+  })
+})

--- a/test/integration/world-storage/get-world-usage-controller.spec.ts
+++ b/test/integration/world-storage/get-world-usage-controller.spec.ts
@@ -1,0 +1,148 @@
+import type { AuthIdentity } from '@dcl/crypto'
+import type { signedFetchFactory } from 'decentraland-crypto-fetch'
+import { calculateValueSizeInBytes } from '../../../src/utils/calculateValueSizeInBytes'
+import { test } from '../../components'
+import { TEST_REALM_METADATA } from '../utils/auth'
+import { createTestSetup } from '../utils/setup'
+
+test('when getting world storage usage', function ({ components, stubComponents }) {
+  let signedFetch: ReturnType<typeof signedFetchFactory>
+  let baseUrl: string
+  let resetStubs: () => void
+  let identity: AuthIdentity
+  let maxTotalSizeBytes: number
+
+  beforeEach(async () => {
+    const setup = await createTestSetup(components, stubComponents)
+    signedFetch = setup.signedFetch
+    baseUrl = setup.baseUrl
+    identity = setup.identity
+    resetStubs = setup.resetStubs
+    maxTotalSizeBytes = await components.config.requireNumber('WORLD_STORAGE_MAX_TOTAL_SIZE_BYTES')
+  })
+
+  afterEach(() => {
+    resetStubs()
+  })
+
+  describe('and the request does not include an identity', () => {
+    let response: Awaited<ReturnType<typeof signedFetch>>
+
+    beforeEach(async () => {
+      response = await signedFetch(`${baseUrl}/usage`, { method: 'GET' })
+    })
+
+    it('should respond with a 400 and a signed fetch required message', async () => {
+      const body = await response.json()
+      expect(response.status).toBe(400)
+      expect(body).toEqual({
+        error: 'Invalid Auth Chain',
+        message: 'This endpoint requires a signed fetch request. See ADR-44.'
+      })
+    })
+  })
+
+  describe('and no values exist', () => {
+    let response: Awaited<ReturnType<typeof signedFetch>>
+
+    beforeEach(async () => {
+      await signedFetch(`${baseUrl}/values`, {
+        method: 'DELETE',
+        headers: { 'X-Confirm-Delete-All': 'true' },
+        identity,
+        metadata: TEST_REALM_METADATA
+      })
+
+      response = await signedFetch(`${baseUrl}/usage`, {
+        method: 'GET',
+        identity,
+        metadata: TEST_REALM_METADATA
+      })
+    })
+
+    it('should respond with a 200 and zero used bytes', async () => {
+      const body = await response.json()
+      expect(response.status).toBe(200)
+      expect(body).toEqual({
+        usedBytes: 0,
+        maxTotalSizeBytes
+      })
+    })
+  })
+
+  describe('and values exist', () => {
+    let expectedUsedBytes: number
+
+    beforeEach(async () => {
+      const storedItems = [
+        { key: 'alpha-key', value: { foo: 'bar' } },
+        { key: 'beta-key', value: 123 },
+        { key: 'gamma-key', value: 'string-value' }
+      ]
+      expectedUsedBytes = storedItems.reduce(
+        (total, item) => total + calculateValueSizeInBytes(JSON.stringify(item.value)),
+        0
+      )
+
+      await Promise.all(
+        storedItems.map(item =>
+          signedFetch(`${baseUrl}/values/${item.key}`, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ value: item.value }),
+            identity,
+            metadata: TEST_REALM_METADATA
+          })
+        )
+      )
+    })
+
+    afterEach(async () => {
+      await signedFetch(`${baseUrl}/values`, {
+        method: 'DELETE',
+        headers: { 'X-Confirm-Delete-All': 'true' },
+        identity,
+        metadata: TEST_REALM_METADATA
+      })
+    })
+
+    it('should respond with a 200 and the current usage and max limit', async () => {
+      const response = await signedFetch(`${baseUrl}/usage`, {
+        method: 'GET',
+        identity,
+        metadata: TEST_REALM_METADATA
+      })
+      const body = await response.json()
+
+      expect(response.status).toBe(200)
+      expect(body).toEqual({
+        usedBytes: expectedUsedBytes,
+        maxTotalSizeBytes
+      })
+    })
+  })
+
+  describe('and the storage throws an error', () => {
+    beforeEach(() => {
+      stubComponents.worldStorage.getSizeInfo.rejects(new Error('boom'))
+    })
+
+    afterEach(() => {
+      stubComponents.worldStorage.getSizeInfo.reset()
+    })
+
+    it('should respond with a 500 and the error message', async () => {
+      const response = await signedFetch(`${baseUrl}/usage`, {
+        method: 'GET',
+        identity,
+        metadata: TEST_REALM_METADATA
+      })
+      const body = await response.json()
+
+      expect(response.status).toBe(500)
+      expect(body).toEqual({
+        error: 'Internal Server Error'
+      })
+    })
+  })
+})

--- a/test/integration/world-storage/get-world-usage-controller.spec.ts
+++ b/test/integration/world-storage/get-world-usage-controller.spec.ts
@@ -29,7 +29,7 @@ test('when getting world storage usage', function ({ components, stubComponents 
     let response: Awaited<ReturnType<typeof signedFetch>>
 
     beforeEach(async () => {
-      response = await signedFetch(`${baseUrl}/usage`, { method: 'GET' })
+      response = await signedFetch(`${baseUrl}/usage/world`, { method: 'GET' })
     })
 
     it('should respond with a 400 and a signed fetch required message', async () => {
@@ -53,7 +53,7 @@ test('when getting world storage usage', function ({ components, stubComponents 
         metadata: TEST_REALM_METADATA
       })
 
-      response = await signedFetch(`${baseUrl}/usage`, {
+      response = await signedFetch(`${baseUrl}/usage/world`, {
         method: 'GET',
         identity,
         metadata: TEST_REALM_METADATA
@@ -107,7 +107,7 @@ test('when getting world storage usage', function ({ components, stubComponents 
     })
 
     it('should respond with a 200 and the current usage and max limit', async () => {
-      const response = await signedFetch(`${baseUrl}/usage`, {
+      const response = await signedFetch(`${baseUrl}/usage/world`, {
         method: 'GET',
         identity,
         metadata: TEST_REALM_METADATA
@@ -132,7 +132,7 @@ test('when getting world storage usage', function ({ components, stubComponents 
     })
 
     it('should respond with a 500 and the error message', async () => {
-      const response = await signedFetch(`${baseUrl}/usage`, {
+      const response = await signedFetch(`${baseUrl}/usage/world`, {
         method: 'GET',
         identity,
         metadata: TEST_REALM_METADATA

--- a/test/mocks/components/env-storage.ts
+++ b/test/mocks/components/env-storage.ts
@@ -8,6 +8,6 @@ export function createEnvStorageMockedComponent(): jest.Mocked<IEnvStorageCompon
     deleteAll: jest.fn(),
     listKeys: jest.fn(),
     countKeys: jest.fn(),
-    getUpsertSizeInfo: jest.fn()
+    getSizeInfo: jest.fn()
   }
 }

--- a/test/mocks/components/player-storage.ts
+++ b/test/mocks/components/player-storage.ts
@@ -11,6 +11,6 @@ export function createPlayerStorageMockedComponent(): jest.Mocked<IPlayerStorage
     countKeys: jest.fn(),
     listPlayers: jest.fn(),
     countPlayers: jest.fn(),
-    getUpsertSizeInfo: jest.fn()
+    getSizeInfo: jest.fn()
   }
 }

--- a/test/mocks/components/world-storage.ts
+++ b/test/mocks/components/world-storage.ts
@@ -8,6 +8,6 @@ export function createWorldStorageMockedComponent(): jest.Mocked<IWorldStorageCo
     deleteAll: jest.fn(),
     listValues: jest.fn(),
     countKeys: jest.fn(),
-    getUpsertSizeInfo: jest.fn()
+    getSizeInfo: jest.fn()
   }
 }

--- a/test/unit/logic/storage-limits.spec.ts
+++ b/test/unit/logic/storage-limits.spec.ts
@@ -88,7 +88,7 @@ describe('Storage Limits Component', () => {
       beforeEach(() => {
         // JSON.stringify adds 2 bytes for quotes, so value length + 2 <= 1024
         value = 'a'.repeat(1022)
-        worldStorage.getUpsertSizeInfo.mockResolvedValueOnce({ existingValueSize: 0, totalSize: 0 })
+        worldStorage.getSizeInfo.mockResolvedValueOnce({ existingValueSize: 0, totalSize: 0 })
       })
 
       it('should resolve without throwing', async () => {
@@ -101,7 +101,7 @@ describe('Storage Limits Component', () => {
 
       beforeEach(() => {
         value = 'x'.repeat(200)
-        worldStorage.getUpsertSizeInfo.mockResolvedValueOnce({ existingValueSize: 0, totalSize: 4900 })
+        worldStorage.getSizeInfo.mockResolvedValueOnce({ existingValueSize: 0, totalSize: 4900 })
       })
 
       it('should throw a StorageLimitExceededError about total size exceeded', async () => {
@@ -115,7 +115,7 @@ describe('Storage Limits Component', () => {
       beforeEach(() => {
         // current: 5000 (at limit), old: 302 bytes, new: ~7 bytes (JSON "small") -> projected: 5000 - 302 + 7 = 4705 <= 5000
         // A new key with the same value would fail: 5000 - 0 + 7 = 5007 > 5000
-        worldStorage.getUpsertSizeInfo.mockResolvedValueOnce({ existingValueSize: 302, totalSize: 5000 })
+        worldStorage.getSizeInfo.mockResolvedValueOnce({ existingValueSize: 302, totalSize: 5000 })
       })
 
       it('should resolve without throwing because the old value size is subtracted', async () => {
@@ -125,16 +125,16 @@ describe('Storage Limits Component', () => {
 
     describe('and all limits are within bounds for a new key', () => {
       beforeEach(() => {
-        worldStorage.getUpsertSizeInfo.mockResolvedValueOnce({ existingValueSize: 0, totalSize: 100 })
+        worldStorage.getSizeInfo.mockResolvedValueOnce({ existingValueSize: 0, totalSize: 100 })
       })
 
       it('should resolve without throwing', async () => {
         await expect(component.validateWorldStorageUpsert(worldName, key, 'hello')).resolves.not.toThrow()
       })
 
-      it('should call getUpsertSizeInfo with the world name and key', async () => {
+      it('should call getSizeInfo with the world name and key', async () => {
         await component.validateWorldStorageUpsert(worldName, key, 'hello')
-        expect(worldStorage.getUpsertSizeInfo).toHaveBeenCalledWith(worldName, key)
+        expect(worldStorage.getSizeInfo).toHaveBeenCalledWith(worldName, key)
       })
     })
   })
@@ -169,7 +169,7 @@ describe('Storage Limits Component', () => {
       beforeEach(() => {
         // JSON.stringify adds 2 bytes for quotes, so value length + 2 <= 512
         value = 'a'.repeat(510)
-        playerStorage.getUpsertSizeInfo.mockResolvedValueOnce({ existingValueSize: 0, totalSize: 0 })
+        playerStorage.getSizeInfo.mockResolvedValueOnce({ existingValueSize: 0, totalSize: 0 })
       })
 
       it('should resolve without throwing', async () => {
@@ -182,7 +182,7 @@ describe('Storage Limits Component', () => {
 
       beforeEach(() => {
         value = 'x'.repeat(200)
-        playerStorage.getUpsertSizeInfo.mockResolvedValueOnce({ existingValueSize: 0, totalSize: 1900 })
+        playerStorage.getSizeInfo.mockResolvedValueOnce({ existingValueSize: 0, totalSize: 1900 })
       })
 
       it('should throw a StorageLimitExceededError about total size exceeded', async () => {
@@ -196,7 +196,7 @@ describe('Storage Limits Component', () => {
       beforeEach(() => {
         // current: 2000 (at limit), old: 200 bytes, new: ~7 bytes (JSON "small") -> projected: 2000 - 200 + 7 = 1807 <= 2000
         // A new key with the same value would fail: 2000 - 0 + 7 = 2007 > 2000
-        playerStorage.getUpsertSizeInfo.mockResolvedValueOnce({ existingValueSize: 200, totalSize: 2000 })
+        playerStorage.getSizeInfo.mockResolvedValueOnce({ existingValueSize: 200, totalSize: 2000 })
       })
 
       it('should resolve without throwing because the old value size is subtracted', async () => {
@@ -208,7 +208,7 @@ describe('Storage Limits Component', () => {
 
     describe('and all limits are within bounds for a new key', () => {
       beforeEach(() => {
-        playerStorage.getUpsertSizeInfo.mockResolvedValueOnce({ existingValueSize: 0, totalSize: 100 })
+        playerStorage.getSizeInfo.mockResolvedValueOnce({ existingValueSize: 0, totalSize: 100 })
       })
 
       it('should resolve without throwing', async () => {
@@ -217,9 +217,9 @@ describe('Storage Limits Component', () => {
         ).resolves.not.toThrow()
       })
 
-      it('should call getUpsertSizeInfo with the world name, player address, and key', async () => {
+      it('should call getSizeInfo with the world name, player address, and key', async () => {
         await component.validatePlayerStorageUpsert(worldName, playerAddress, key, 'hello')
-        expect(playerStorage.getUpsertSizeInfo).toHaveBeenCalledWith(worldName, playerAddress, key)
+        expect(playerStorage.getSizeInfo).toHaveBeenCalledWith(worldName, playerAddress, key)
       })
     })
   })
@@ -250,7 +250,7 @@ describe('Storage Limits Component', () => {
 
     describe('and the value size is exactly at the limit', () => {
       beforeEach(() => {
-        envStorage.getUpsertSizeInfo.mockResolvedValueOnce({ existingValueSize: 0, totalSize: 0 })
+        envStorage.getSizeInfo.mockResolvedValueOnce({ existingValueSize: 0, totalSize: 0 })
       })
 
       it('should resolve without throwing because env values are measured as raw strings', async () => {
@@ -264,7 +264,7 @@ describe('Storage Limits Component', () => {
 
       beforeEach(() => {
         value = 'x'.repeat(60)
-        envStorage.getUpsertSizeInfo.mockResolvedValueOnce({ existingValueSize: 0, totalSize: 450 })
+        envStorage.getSizeInfo.mockResolvedValueOnce({ existingValueSize: 0, totalSize: 450 })
       })
 
       it('should throw a StorageLimitExceededError about total size exceeded', async () => {
@@ -278,7 +278,7 @@ describe('Storage Limits Component', () => {
       beforeEach(() => {
         // current: 500 (at limit), old: 30 bytes, new: 7 bytes ("updated") -> projected: 500 - 30 + 7 = 477 <= 500
         // A new key with the same value would fail: 500 - 0 + 7 = 507 > 500
-        envStorage.getUpsertSizeInfo.mockResolvedValueOnce({ existingValueSize: 30, totalSize: 500 })
+        envStorage.getSizeInfo.mockResolvedValueOnce({ existingValueSize: 30, totalSize: 500 })
       })
 
       it('should resolve without throwing because the old value size is subtracted', async () => {
@@ -288,16 +288,16 @@ describe('Storage Limits Component', () => {
 
     describe('and all limits are within bounds for a new key', () => {
       beforeEach(() => {
-        envStorage.getUpsertSizeInfo.mockResolvedValueOnce({ existingValueSize: 0, totalSize: 50 })
+        envStorage.getSizeInfo.mockResolvedValueOnce({ existingValueSize: 0, totalSize: 50 })
       })
 
       it('should resolve without throwing', async () => {
         await expect(component.validateEnvStorageUpsert(worldName, key, 'my-secret')).resolves.not.toThrow()
       })
 
-      it('should call getUpsertSizeInfo with the world name and key', async () => {
+      it('should call getSizeInfo with the world name and key', async () => {
         await component.validateEnvStorageUpsert(worldName, key, 'my-secret')
-        expect(envStorage.getUpsertSizeInfo).toHaveBeenCalledWith(worldName, key)
+        expect(envStorage.getSizeInfo).toHaveBeenCalledWith(worldName, key)
       })
     })
   })


### PR DESCRIPTION
## Summary

Adds three usage endpoints (world, env, player) that return `usedBytes` and `maxTotalSizeBytes` for the storage UI. Refactors persistence from `getUpsertSizeInfo` to `getSizeInfo` with optional `key` so the same query path powers both upsert limit checks and usage reads.

Closes #74.

---

## What changed

- **New endpoints**
  - `GET /usage` — world storage usage
  - `GET /env/usage` — env storage usage (world-scoped)
  - `GET /players/:player_address/usage` — player storage usage

  All return `200` with `{ usedBytes, maxTotalSizeBytes }`, use existing Signed Fetch auth, and are documented in OpenAPI (including `StorageUsageResponse` and error responses).

- **Player usage**
  - Path param `player_address` is validated; invalid address returns `400` with message `Invalid player address`. Address is normalized to lowercase.

- **Routing**
  - `/env/usage` is registered before `/env/:key` so "usage" is not interpreted as a key.

- **Adapters (world, player, env)**
  - `getUpsertSizeInfo(worldName, key)` → `getSizeInfo(worldName, key?)`.
  - With `key`: same behavior as before (existing value size + total size for upsert limit).
  - Without `key`: `existingValueSize` is 0, only total size is used (for usage endpoints). Implemented via a single query using `MAX(value_size) FILTER (WHERE key = $keyFilter)` with `keyFilter = key ?? null` so one method serves both cases.

- **Domain**
  - `storage-limits` now calls `getSizeInfo(..., key)`; upsert limit behavior is unchanged.

- **Types**
  - `StorageUsageResponse` and `HTTPStorageUsageResponse` in `src/types/http.ts`; adapter interfaces and mocks updated for `getSizeInfo`.

- **Tests**
  - Integration specs for all three usage endpoints (auth, empty/populated scope, invalid player, component error).
  - Unit tests and mocks updated for the adapter rename.

---

## Rationale

- **Single query path**  
  Usage endpoints need only total size; upsert needs total size plus size of the key being written. Making `key` optional in `getSizeInfo` keeps one SQL shape and one method name instead of adding a separate “get total only” API.

- **No schema or auth changes**  
  Reuses existing tables and config (`*_MAX_TOTAL_SIZE_BYTES`). Same auth as other storage endpoints (Signed Fetch; env keeps owner/deployer checks).

- **Route order**  
  `/env/usage` before `/env/:key` avoids "usage" being treated as an env key.